### PR TITLE
ci: fix workflow permissions issue

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Deploy Application
+      - name: Deploy Application to server
         env:
             PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
             HOSTNAME: ${{ secrets.SSH_HOST }}
@@ -35,5 +35,5 @@ jobs:
           git pull origin main
           source venv/bin/activate
           pip3 install -r requirements.txt
-          systemctl restart fastapi-book-project
+          sudo systemctl restart fastapi-book-project
           EOF


### PR DESCRIPTION
## **Description**  
- Updated GitHub Actions workflow to include `sudo` in the systemctl restart command.  

## **Testing**  
- Manually tested service restart using:  
  ```bash
  sudo systemctl restart fastapi-book-project.service
  ```  
- Verified deployment by running:  
  ```bash
  systemctl status fastapi-book-project.service
  ```  

## **Notes**  
- Deployment should now complete without interactive authentication errors.  
- The application should restart automatically upon merging to `main`.  
- Deployment URL: https://16.171.35.27 